### PR TITLE
Nerfs Smartgun and Smartrifle penetration stat

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -1017,13 +1017,13 @@ datum/ammo/bullet/revolver/tp44
 	flags_ammo_behavior = AMMO_BALLISTIC|AMMO_SUNDERING
 	accurate_range = 15
 	damage = 20
-	penetration = 15
+	penetration = 10
 	sundering = 2
 
 /datum/ammo/bullet/smartgun/smartrifle
 	name = "smartrifle bullet"
 	damage = 20
-	penetration = 10
+	penetration = 5
 	sundering = 1.5
 
 /datum/ammo/bullet/smartgun/lethal


### PR DESCRIPTION
## About The Pull Request
Per title. The smartgun's penetration stat has been reduced to 10 from 15, and the smartrifle's from 10 to 5.
Checked with David before making the PR, he said he was okay with this.

## Why It's Good For The Game
Makes the SG guns a little bit less oppressive than they are at the moment.

## Changelog
:cl:
balance: Smartgun penetration 15 > 10. Smartrifle penetration 10 > 5.
/:cl: